### PR TITLE
ci: add PR build smoke check

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,26 @@
+name: PR checks
+
+on:
+    pull_request:
+        branches: [master]
+
+jobs:
+    build:
+        name: Build smoke test
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Check out repository
+              uses: actions/checkout@v6
+
+            - name: Set up Node
+              uses: actions/setup-node@v6
+              with:
+                  node-version-file: .nvmrc
+                  cache: yarn
+
+            - name: Install dependencies
+              run: yarn install --frozen-lockfile
+
+            - name: Build
+              run: yarn build


### PR DESCRIPTION
We need to set up some automated checks before merging PRs. So this adds a github action to check PR requests still properly compile.

Changes
- Run yarn build for pull requests targeting master using the Node version from .nvmrc.