### PR TITLE
More CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
       "serialize-javascript": ">=7.0.5",
       "d3-color": ">=3.1.0",
       "picomatch": ">=2.3.2",
-      "path-to-regexp": "0.1.13"
+      "path-to-regexp": "0.1.13",
+      "ajv": ">=8.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
       "follow-redirects": "^1.16.0",
       "serialize-javascript": ">=7.0.5",
       "d3-color": ">=3.1.0",
-      "picomatch": ">=2.3.2"
+      "picomatch": ">=2.3.2",
+      "path-to-regexp": "0.1.13"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2915,10 +2915,10 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-to-regexp@~0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
-  integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
+path-to-regexp@0.1.13, path-to-regexp@~0.1.12:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.13.tgz#9b22ec16bc3ab88d05a0c7e369869421401ab17d"
+  integrity sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==
 
 picocolors@^1.1.1:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,10 +1503,10 @@ ajv-keywords@^5.1.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@^8.0.0, ajv@^8.9.0:
-  version "8.17.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
-  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+ajv@>=8.18.0, ajv@^8.0.0, ajv@^8.9.0:
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.20.0.tgz#304b3636add88ba7d936760dd50ece006dea95f9"
+  integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
   dependencies:
     fast-deep-equal "^3.1.3"
     fast-uri "^3.0.1"


### PR DESCRIPTION
This resolves something like 4 vulnerabilities, but not my ability to spell vulnerability. 

 fix: resolve ajv CVE
    
    Force ajv to a patched version via yarn resolutions to address the
    webpack > schema-utils transitive audit advisory.

fix: resolve path-to-regexp CVE
    
    Force path-to-regexp to 0.1.13 via yarn resolutions to address the
    webpack-dev-server > express transitive advisory.